### PR TITLE
Fix tt range in non-parallel kalmanfilter

### DIFF
--- a/src/Kalman.jl
+++ b/src/Kalman.jl
@@ -166,7 +166,7 @@ Kalman filter
 function kalmanfilter(yy::AbstractMatrix, M::LinearHomogSystem) 
     d = size(M.Phi, 1)
     n = size(yy, 2)
-    kalmanfilter!(1:n, yy, zeros(d, n), zeros(d, d, n), zeros(d, d, n), M) 
+    kalmanfilter!(0:n, yy, zeros(d, n), zeros(d, d, n), zeros(d, d, n), M)
 end
 
 """


### PR DESCRIPTION
The other `kalmanfilter` methods use `0:n`, and it's necessary, otherwise we get a bounds error. If I'm understanding this right, `tt` is the "time", which you've implemented presumably to eventually support varying time steps? And `tt[1]` is the "time of the initial condition"?