### PR TITLE
Remove GaussianDistributions from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
 
 Distributions
-GaussianDistributions


### PR DESCRIPTION
You can't have `GaussianDistributions` in REQUIRE because it errors out on Travis every time someone `Pkg.clone`s `Kalman.jl`. Unless you register `GaussianDistributions` and then you should add it to the REQUIRE file.