### PR TITLE
Update README.md to make copy-paste runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ A very similar example of tracking a 2D trajectory can be found [here](example/t
 The same might be achieved using interface functions
 
 ```julia
-using GaussianDistributions
-using DynamicIterators
+using DynamicIterators, GaussianDistributions, Kalman, LinearAlgebra
 
 # Define linear evolution
 Φ = [0.8 0.5; -0.1 0.8]
@@ -117,12 +116,13 @@ a possible the implementation of `kalmanfilter` to see how filtering can be inte
 
 # Initialise dynamical filter with first data point `t => v`
 # and the `prior::Pair{Int,<:Gaussian}`, a pair of initial time and initial state
+prior = 0 => Gaussian(x0, P0)
 
 ϕ = dyniterate(O, Start(Kalman.Filter(prior, 0.0)), t => v)
 ϕ === nothing && error("no observations")
 (t, u), state = ϕ
 
-X = trajectory((t => u[1],))
+X = [t => u[1]]
 while true
 
     # Advance data iterator


### PR DESCRIPTION
Little tweaks to README.md to make the 2nd and 3rd snippet runnable in isolation of the first by copy-pasting into REPL.
 - added `using Kalman, LinearAlgebra` so that the 2nd+3rd snippet run without having to have run the first snippet first.
 - `prior` wasn't defined so I guessed at what was intended.
 - `trajectory` wasn't defined so I turned `X` into an array