### PR TITLE
Matrix-free observation operator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DynamicIterators = "6c76993d-992e-5bf1-9e63-34920a5a5a38"
 GaussianDistributions = "43dcc890-d446-5863-8d1a-14597580bb8d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Trajectories = "2c80a279-213e-54d7-a557-e9a14725db56"
 

--- a/example/matrixfree.jl
+++ b/example/matrixfree.jl
@@ -1,0 +1,45 @@
+using Kalman, GaussianDistributions, LinearAlgebra
+using GaussianDistributions: ⊕ # independent sum of Gaussian r.v.
+using Statistics
+
+# prior for time 0
+x0 = [-1., 1.]
+P0 = Matrix(1.0I, 2, 2)
+
+# dynamics
+Φ = [0.8 0.2; -0.1 0.8]
+b = zeros(2)
+Q = [0.2 0.0; 0.0 0.5]
+
+# matrix free observation operator
+using LinearMaps
+h(x) = [x[1]]
+
+R = Matrix(0.3I, 1, 1)
+
+# (mock) data
+ys = [[-1.77], [-0.78], [-1.28], [-1.06], [-3.65], [-2.47], [-0.06], [-0.91], [-0.80], [1.48]]
+
+
+# filter (assuming first observation at time 1)
+N = length(ys)
+H = [LinearMap(h, 1, 2) for i in 1:N]
+
+p = Gaussian(x0, P0)
+ps = [p] # vector of filtered Gaussians
+for i in 1:N
+    global p
+    # predict
+    p = Φ*p ⊕ Gaussian(zero(x0), Q) #same as Gaussian(Φ*p.μ, Φ*p.Σ*Φ' + Q)
+    # correct
+    p, yres, _ = Kalman.correct(Kalman.JosephForm(), p, (Gaussian(ys[i], R), H[i]))
+    push!(ps, p) # save filtered density
+end
+
+using Plots
+
+p1 = scatter(1:N, first.(ys), color="red", label="observations y")
+plot!(p1, 0:N, [mean(p)[1] for p in ps], color="orange", label="filtered x1", grid=false, ribbon=[sqrt(cov(p)[1,1]) for p in ps], fillalpha=.5)
+plot!(p1, 0:N, [mean(p)[2] for p in ps], color="blue", label="filtered x2", grid=false, ribbon=[sqrt(cov(p)[2,2]) for p in ps], fillalpha=.5)
+
+savefig(p1, "filter.png")

--- a/src/Kalman.jl
+++ b/src/Kalman.jl
@@ -9,6 +9,7 @@ import Base: iterate, IteratorSize, IteratorEltype, eltype, length
 
 import Random.rand
 import GaussianDistributions: ⊕
+using LinearMaps
 
 meancov(G) = mean(G), cov(G)
 meancov(G::Tuple) = G

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -35,7 +35,6 @@ function correct(method::JosephForm, u::T, (v, H)::Tuple{<:Gaussian, <:Any}) whe
 end
 
 function correct(method::JosephForm, u::T, (v, H)::Tuple{<:Gaussian, <:LinearMap}) where T
-    println("Here")
     x, Ppred = meancov(u)
     y, R = meancov(v)
     yres = y - H*x # innovation residual

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -34,6 +34,22 @@ function correct(method::JosephForm, u::T, (v, H)::Tuple{<:Gaussian, <:Any}) whe
     T(x, P), yres, S
 end
 
+function correct(method::JosephForm, u::T, (v, H)::Tuple{<:Gaussian, <:LinearMap}) where T
+    println("Here")
+    x, Ppred = meancov(u)
+    y, R = meancov(v)
+    yres = y - H*x # innovation residual
+    HP = Matrix(H*Ppred)
+
+    S = Matrix(H*HP')' + R # innovation covariance
+
+    K = Matrix(H*Ppred')'/S # Kalman gain
+    x = x + K*yres
+    A = I - Matrix(K*H)
+    P = A*Ppred*A' + K*R*K'
+    T(x, P), yres, S
+end
+
 """
 
 Single Kalman filter with control being the observation, consisting of a prediction step


### PR DESCRIPTION
See the example for use. I changed the `correct` method a bit to instantiate some of the objects as matrices and allow for linear maps

```
function correct(method::JosephForm, u::T, (v, H)::Tuple{<:Gaussian, <:LinearMap}) where T
    x, Ppred = meancov(u)
    y, R = meancov(v)
    yres = y - H*x # innovation residual
    HP = Matrix(H*Ppred)

    S = Matrix(H*HP')' + R # innovation covariance

    K = Matrix(H*Ppred')'/S # Kalman gain
    x = x + K*yres
    A = I - Matrix(K*H)
    P = A*Ppred*A' + K*R*K'
    T(x, P), yres, S
end
```