### PR TITLE
Remove unused type variable

### DIFF
--- a/src/backwardsampler.jl
+++ b/src/backwardsampler.jl
@@ -1,5 +1,5 @@
 
-function backward_rand_kernel(x, Gf, Gpred, Φ) where T
+function backward_rand_kernel(x, Gf, Gpred, Φ)
     xf, Pf = meancov(Gf)
     xpred, Ppred = meancov(Gpred)
 


### PR DESCRIPTION
`backwardsampler` declares type variable `T` but does not use it, so I removed it.